### PR TITLE
feat: scripts failsafes

### DIFF
--- a/.changeset/purple-otters-rush.md
+++ b/.changeset/purple-otters-rush.md
@@ -1,0 +1,7 @@
+---
+"@tools/eslint-config": patch
+"react-native-storybook-visual": patch
+"@local/ui": patch
+---
+
+Revert to using WebSocket events to progress stories, add error handling and failsafes to scripts

--- a/.yarn/patches/@storybook-react-native-patch-f4727190cb.patch
+++ b/.yarn/patches/@storybook-react-native-patch-f4727190cb.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index 7412f412ce63514f32a66dfa616c073db505628e..fa925478bd67030e66d2324740e2132072b24276 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -97,6 +97,7 @@ type DeepPartial<T> = T extends object ? {
+ type Params = {
+     onDeviceUI?: boolean;
+     enableWebsockets?: boolean;
++    onWsConnectionError?: (e: Error) => void;
+     query?: string;
+     host?: string;
+     port?: number;
+diff --git a/dist/index.js b/dist/index.js
+index 367f405c1d2958a4525a7dd2232b7d77b627f79b..b52d50a17863d0817a89606735302737c2698331 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1381,7 +1381,8 @@ var View10 = class {
+     return (0, import_channel_websocket.default)({
+       url,
+       async: true,
+-      onError: async () => {
++      onError: async (e) => {
++        params.onWsConnectionError?.(e)
+       }
+     });
+   };

--- a/apps/bare/.storybook/index.ts
+++ b/apps/bare/.storybook/index.ts
@@ -4,6 +4,12 @@ import "./storybook.requires";
 
 const StorybookUIRoot = getStorybookUI({
   enableWebsockets: true,
+  onWsConnectionError: (e) => {
+    console.error(
+      "Error connecting to the Storybook WebSocket server. Restart the Storybook server and try again. Error:",
+      e.message
+    );
+  },
   onDeviceUI: false,
   port: 7007,
 });

--- a/apps/bare/package.json
+++ b/apps/bare/package.json
@@ -36,7 +36,7 @@
     "@storybook/addon-ondevice-controls": "^6.5.7",
     "@storybook/addons": "^6.5.16",
     "@storybook/react": "^6.5.16",
-    "@storybook/react-native": "patch:@storybook/react-native@npm%3A6.5.7#~/.yarn/patches/@storybook-react-native-npm-6.5.7-7555f80731.patch",
+    "@storybook/react-native": "patch:@storybook/react-native@patch%3A@storybook/react-native@npm%253A6.5.7%23~/.yarn/patches/@storybook-react-native-npm-6.5.7-7555f80731.patch%3A%3Aversion=6.5.7&hash=8102a7#~/.yarn/patches/@storybook-react-native-patch-f4727190cb.patch",
     "@storybook/react-native-server": "^6.5.7",
     "@types/react": "^18.2.43",
     "@types/react-test-renderer": "^18.0.0",

--- a/apps/expo/.storybook/index.ts
+++ b/apps/expo/.storybook/index.ts
@@ -4,6 +4,12 @@ import "./storybook.requires";
 
 const StorybookUIRoot = getStorybookUI({
   enableWebsockets: true,
+  onWsConnectionError: (e) => {
+    console.error(
+      "Error connecting to the Storybook WebSocket server. Restart the Storybook server and try again. Error:",
+      e.message
+    );
+  },
   onDeviceUI: false,
   port: 7007,
 });

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -33,7 +33,7 @@
     "@storybook/addon-ondevice-controls": "^6.5.7",
     "@storybook/addons": "^6.5.16",
     "@storybook/react": "^6.5.16",
-    "@storybook/react-native": "patch:@storybook/react-native@npm%3A6.5.7#~/.yarn/patches/@storybook-react-native-npm-6.5.7-7555f80731.patch",
+    "@storybook/react-native": "patch:@storybook/react-native@patch%3A@storybook/react-native@npm%253A6.5.7%23~/.yarn/patches/@storybook-react-native-npm-6.5.7-7555f80731.patch%3A%3Aversion=6.5.7&hash=8102a7#~/.yarn/patches/@storybook-react-native-patch-f4727190cb.patch",
     "@storybook/react-native-server": "^6.5.7",
     "@types/react": "~18.2.43",
     "react-native-storybook-visual": "*",

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -10,5 +10,3 @@ export const getEmojiForPlatform = (platform: Platforms | undefined) => {
       return "📱";
   }
 };
-
-export const delay = (ms: number) => new Promise(res => setTimeout(res, ms));

--- a/packages/tools/eslint-config/library.js
+++ b/packages/tools/eslint-config/library.js
@@ -9,6 +9,7 @@ module.exports = {
   globals: {
     React: true,
     JSX: true,
+    NodeJS: true,
   },
   env: {
     node: true,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,7 +19,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@storybook/react-native": "patch:@storybook/react-native@npm%3A6.5.7#~/.yarn/patches/@storybook-react-native-npm-6.5.7-7555f80731.patch",
+    "@storybook/react-native": "patch:@storybook/react-native@patch%3A@storybook/react-native@npm%253A6.5.7%23~/.yarn/patches/@storybook-react-native-npm-6.5.7-7555f80731.patch%3A%3Aversion=6.5.7&hash=8102a7#~/.yarn/patches/@storybook-react-native-patch-f4727190cb.patch",
     "react": "18.2.0",
     "react-native": "^0.73.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,7 +54,7 @@ __metadata:
     "@storybook/addon-ondevice-controls": "npm:^6.5.7"
     "@storybook/addons": "npm:^6.5.16"
     "@storybook/react": "npm:^6.5.16"
-    "@storybook/react-native": "patch:@storybook/react-native@npm%3A6.5.7#~/.yarn/patches/@storybook-react-native-npm-6.5.7-7555f80731.patch"
+    "@storybook/react-native": "patch:@storybook/react-native@patch%3A@storybook/react-native@npm%253A6.5.7%23~/.yarn/patches/@storybook-react-native-npm-6.5.7-7555f80731.patch%3A%3Aversion=6.5.7&hash=8102a7#~/.yarn/patches/@storybook-react-native-patch-f4727190cb.patch"
     "@storybook/react-native-server": "npm:^6.5.7"
     "@types/react": "npm:^18.2.43"
     "@types/react-test-renderer": "npm:^18.0.0"
@@ -85,7 +85,7 @@ __metadata:
     "@storybook/addon-ondevice-controls": "npm:^6.5.7"
     "@storybook/addons": "npm:^6.5.16"
     "@storybook/react": "npm:^6.5.16"
-    "@storybook/react-native": "patch:@storybook/react-native@npm%3A6.5.7#~/.yarn/patches/@storybook-react-native-npm-6.5.7-7555f80731.patch"
+    "@storybook/react-native": "patch:@storybook/react-native@patch%3A@storybook/react-native@npm%253A6.5.7%23~/.yarn/patches/@storybook-react-native-npm-6.5.7-7555f80731.patch%3A%3Aversion=6.5.7&hash=8102a7#~/.yarn/patches/@storybook-react-native-patch-f4727190cb.patch"
     "@storybook/react-native-server": "npm:^6.5.7"
     "@types/react": "npm:~18.2.43"
     expo: "npm:^49.0.21"
@@ -3215,7 +3215,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@local/ui@workspace:packages/ui"
   dependencies:
-    "@storybook/react-native": "patch:@storybook/react-native@npm%3A6.5.7#~/.yarn/patches/@storybook-react-native-npm-6.5.7-7555f80731.patch"
+    "@storybook/react-native": "patch:@storybook/react-native@patch%3A@storybook/react-native@npm%253A6.5.7%23~/.yarn/patches/@storybook-react-native-npm-6.5.7-7555f80731.patch%3A%3Aversion=6.5.7&hash=8102a7#~/.yarn/patches/@storybook-react-native-patch-f4727190cb.patch"
     "@tools/tsconfig": "npm:*"
     "@types/react": "npm:^18.2.43"
     "@types/react-native": "npm:^0.72.8"
@@ -5504,7 +5504,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/react-native@npm:6.5.7, @storybook/react-native@npm:^6.5.7":
+"@storybook/react-native@npm:6.5.7":
   version: 6.5.7
   resolution: "@storybook/react-native@npm:6.5.7"
   dependencies:
@@ -5538,7 +5538,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/react-native@patch:@storybook/react-native@npm%3A6.5.7#~/.yarn/patches/@storybook-react-native-npm-6.5.7-7555f80731.patch":
+"@storybook/react-native@patch:@storybook/react-native@npm%3A6.5.7#~/.yarn/patches/@storybook-react-native-npm-6.5.7-7555f80731.patch::version=6.5.7&hash=8102a7":
   version: 6.5.7
   resolution: "@storybook/react-native@patch:@storybook/react-native@npm%3A6.5.7#~/.yarn/patches/@storybook-react-native-npm-6.5.7-7555f80731.patch::version=6.5.7&hash=8102a7"
   dependencies:
@@ -5569,6 +5569,40 @@ __metadata:
     sb-rn-get-stories: bin/get-stories.js
     sb-rn-watcher: bin/watcher.js
   checksum: fc18d646fb47ae88c68a0bc2d34d2b255690a7cb1396b58bb0568746db0aecd06e0e26bab7ad764ac3ae8cb06237a0bb4ec38b3a80ae62f259b77c3eb960a330
+  languageName: node
+  linkType: hard
+
+"@storybook/react-native@patch:@storybook/react-native@patch%3A@storybook/react-native@npm%253A6.5.7%23~/.yarn/patches/@storybook-react-native-npm-6.5.7-7555f80731.patch%3A%3Aversion=6.5.7&hash=8102a7#~/.yarn/patches/@storybook-react-native-patch-f4727190cb.patch":
+  version: 6.5.7
+  resolution: "@storybook/react-native@patch:@storybook/react-native@patch%3A@storybook/react-native@npm%253A6.5.7%23~/.yarn/patches/@storybook-react-native-npm-6.5.7-7555f80731.patch%3A%3Aversion=6.5.7&hash=8102a7#~/.yarn/patches/@storybook-react-native-patch-f4727190cb.patch::version=6.5.7&hash=582d38"
+  dependencies:
+    "@storybook/addons": "npm:^6.5.14"
+    "@storybook/channel-websocket": "npm:^6.5.14"
+    "@storybook/channels": "npm:^6.5.14"
+    "@storybook/client-api": "npm:^6.5.14"
+    "@storybook/client-logger": "npm:^6.5.14"
+    "@storybook/core-client": "npm:^6.5.14"
+    "@storybook/core-events": "npm:^6.5.14"
+    "@storybook/csf": "npm:0.0.2--canary.4566f4d.1"
+    "@storybook/preview-web": "npm:^6.5.14"
+    "@storybook/react-native-theming": "npm:^6.5.7"
+    chokidar: "npm:^3.5.1"
+    commander: "npm:^8.2.0"
+    deepmerge: "npm:^4.3.0"
+    glob: "npm:^7.1.7"
+    jotai: "npm:^2.0.2"
+    prettier: "npm:^2.4.1"
+    react-native-swipe-gestures: "npm:^1.0.5"
+    util: "npm:^0.12.4"
+  peerDependencies:
+    "@react-native-async-storage/async-storage": ">=1"
+    react: "*"
+    react-native: ">=0.57.0"
+    react-native-safe-area-context: "*"
+  bin:
+    sb-rn-get-stories: bin/get-stories.js
+    sb-rn-watcher: bin/watcher.js
+  checksum: 7e01611a5e6adc06e8c6fcae35cffd9fdfcb8f6f53ca9c4c62fbc3483daffbf96d055b6cc8efb5d87a791256928a8bb47e9af1f8e649c2c0ce0ad66aadadf25d
   languageName: node
   linkType: hard
 
@@ -18749,7 +18783,7 @@ __metadata:
     "@storybook/core-common": "npm:^6.5.16"
     "@storybook/core-events": "npm:^6.5.16"
     "@storybook/csf-tools": "npm:^6.5.16"
-    "@storybook/react-native": "npm:^6.5.7"
+    "@storybook/react-native": "patch:@storybook/react-native@patch%3A@storybook/react-native@npm%253A6.5.7%23~/.yarn/patches/@storybook-react-native-npm-6.5.7-7555f80731.patch%3A%3Aversion=6.5.7&hash=8102a7#~/.yarn/patches/@storybook-react-native-patch-f4727190cb.patch"
     "@tools/eslint-config": "npm:*"
     "@tools/tsconfig": "npm:*"
     "@types/figlet": "npm:^1.5.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5504,7 +5504,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/react-native@npm:6.5.7":
+"@storybook/react-native@npm:6.5.7, @storybook/react-native@npm:^6.5.7":
   version: 6.5.7
   resolution: "@storybook/react-native@npm:6.5.7"
   dependencies:
@@ -18783,7 +18783,7 @@ __metadata:
     "@storybook/core-common": "npm:^6.5.16"
     "@storybook/core-events": "npm:^6.5.16"
     "@storybook/csf-tools": "npm:^6.5.16"
-    "@storybook/react-native": "patch:@storybook/react-native@patch%3A@storybook/react-native@npm%253A6.5.7%23~/.yarn/patches/@storybook-react-native-npm-6.5.7-7555f80731.patch%3A%3Aversion=6.5.7&hash=8102a7#~/.yarn/patches/@storybook-react-native-patch-f4727190cb.patch"
+    "@storybook/react-native": "npm:^6.5.7"
     "@tools/eslint-config": "npm:*"
     "@tools/tsconfig": "npm:*"
     "@types/figlet": "npm:^1.5.8"


### PR DESCRIPTION
- When using `getStorybookUI` from `@storybook/react-native` with `enableWebsockets: true`, Storybook attempts to establish a connection with the WebSocket server that's assumed to be running on the provided port, but, if there's a connection error (e.g. the server isn't running), `@storybook/react-native` swallows it and fails silently. This PR patches `@storybook/react-native` and exposes the underlying `onError` handler as an `onWsConnectionError` callback, which emits a console error in Metro letting the user know about the issue.
- Instead of delaying the execution by 1s and assuming the story has been rendered after it elapses the script now waits for the first `CURRENT_STORY_WAS_SET` event for the currently processed story and only proceeds after receiving it. If it doesn't, the script exits with an error message after 10 seconds.
(Note: I haven't had any issues with the `CURRENT_STORY_WAS_SET` event like the ones described in https://github.com/slavikdenis/storybook-react-native-vrt/pull/3 with `STORY_RENDERED`. FYI @slavikdenis)